### PR TITLE
Added outline option to shapes

### DIFF
--- a/include/Dualie/Graphics/Shape.hpp
+++ b/include/Dualie/Graphics/Shape.hpp
@@ -15,17 +15,25 @@ namespace dl {
     class Shape : public dl::Transformable, public dl::Drawable {
 
     protected:
-        dl::Color m_color;
+        dl::Color m_fillColor;
+        dl::Color m_outlineColor;
+        float m_outlineThickness;
         dl::Vector2f m_origin;
         dl::Vector2f m_size;
 
     public:
+        Shape();
         void setFillColor(const dl::Color& color);
+        void setOutlineColor(const dl::Color& color);
+        void setOutlineThickness(float thickness);
         void setOrigin(const dl::Vector2f& origin);
 
-        virtual const dl::Vector2f& getSize();
-        virtual dl::FloatRect getLocalBounds();
-        virtual dl::FloatRect getGlobalBounds();
+        const dl::Vector2f& getSize();
+        dl::FloatRect getLocalBounds();
+        dl::FloatRect getGlobalBounds();
+        const Color &getFillColor() const;
+        const Color &getOutlineColor() const;
+        const float& getOutlineThickness();
 
 
 

--- a/src/Dualie/Graphics/CircleShape.cpp
+++ b/src/Dualie/Graphics/CircleShape.cpp
@@ -18,5 +18,8 @@ void dl::CircleShape::setRadius(float radius) {
 }
 
 void dl::CircleShape::draw(const dl::Vector2f& viewOffset) const {
-    C2D_DrawCircle(m_position.x - m_origin.x - viewOffset.x, m_position.y - m_origin.y - viewOffset.y, 0, m_radius, m_color.getColorValue(), m_color.getColorValue(), m_color.getColorValue(), m_color.getColorValue());
+    if(m_outlineThickness > 0){
+        C2D_DrawCircle(m_position.x + m_radius - m_origin.x - viewOffset.x, m_position.y + m_radius - m_origin.y - viewOffset.y, 0, m_radius, m_outlineColor.getColorValue(), m_outlineColor.getColorValue(), m_outlineColor.getColorValue(), m_outlineColor.getColorValue());
+    }
+    C2D_DrawCircle(m_position.x + m_radius - m_origin.x - viewOffset.x, m_position.y + m_radius - m_origin.y - viewOffset.y, 0, m_radius - m_outlineThickness, m_fillColor.getColorValue(), m_fillColor.getColorValue(), m_fillColor.getColorValue(), m_fillColor.getColorValue());
 }

--- a/src/Dualie/Graphics/RectangleShape.cpp
+++ b/src/Dualie/Graphics/RectangleShape.cpp
@@ -17,5 +17,8 @@ void dl::RectangleShape::setSize(const dl::Vector2f &size) {
 }
 
 void dl::RectangleShape::draw(const dl::Vector2f& viewOffset) const {
-    C2D_DrawRectSolid(m_position.x - m_origin.x - viewOffset.x, m_position.y - m_origin.y - viewOffset.y, 0, m_size.x, m_size.y, m_color.getColorValue());
+    if(m_outlineThickness > 0){
+        C2D_DrawRectSolid(m_position.x - m_origin.x - viewOffset.x, m_position.y - m_origin.y - viewOffset.y, 0, m_size.x, m_size.y, m_outlineColor.getColorValue());
+    }
+    C2D_DrawRectSolid(m_position.x + m_outlineThickness - m_origin.x - viewOffset.x, m_position.y + m_outlineThickness - m_origin.y - viewOffset.y, 0, m_size.x - m_outlineThickness * 2.f, m_size.y - m_outlineThickness * 2.f, m_fillColor.getColorValue());
 }

--- a/src/Dualie/Graphics/Shape.cpp
+++ b/src/Dualie/Graphics/Shape.cpp
@@ -4,9 +4,11 @@
 
 #include <Dualie/Graphics/Shape.hpp>
 
+dl::Shape::Shape() : m_outlineThickness(0)
+{}
 
 void dl::Shape::setFillColor(const dl::Color &color) {
-    m_color = color;
+    m_fillColor = color;
 }
 
 void dl::Shape::setOrigin(const dl::Vector2f &origin) {
@@ -21,8 +23,37 @@ dl::FloatRect dl::Shape::getGlobalBounds() {
     return {m_position - m_origin, m_size};
 }
 
+void dl::Shape::setOutlineColor(const dl::Color &color)
+{
+    m_outlineColor = color;
+}
+
+void dl::Shape::setOutlineThickness(float thickness)
+{
+    m_outlineThickness = thickness;
+}
+
+
 const dl::Vector2f &dl::Shape::getSize() {
     return m_size;
 }
+
+const dl::Color &dl::Shape::getFillColor() const
+{
+    return m_fillColor;
+}
+
+const dl::Color &dl::Shape::getOutlineColor() const
+{
+    return m_outlineColor;
+}
+
+
+const float &dl::Shape::getOutlineThickness()
+{
+    return m_outlineThickness;
+}
+
+
 
 


### PR DESCRIPTION
A new shape method `setOutlineThickness` allows for an outline to be drawn. This simply draws another shape behind the original and scales the original shape down to create the appearance of an outline. 