### PR TITLE
Add opus audio support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.28)
 project(dualie)
 
-
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(OPUSFILE REQUIRED IMPORTED_TARGET opusfile)
 
 add_library(dualie STATIC
         include/Dualie/Graphics.hpp
@@ -29,10 +30,16 @@ add_library(dualie STATIC
         include/Dualie/Graphics/Text.hpp
         src/Dualie/Graphics/TextBuffer.cpp
         include/Dualie/Graphics/TextBuffer.hpp
+        src/Dualie/Audio/Music.cpp
+        include/Dualie/Audio/Music.hpp
 )
 
+
+
 target_include_directories(${PROJECT_NAME} PRIVATE include)
+target_include_directories(${PROJECT_NAME} PRIVATE pkg-config opusfile)
 target_link_libraries(${PROJECT_NAME} citro2d citro3d ctru m)
+target_link_libraries(${PROJECT_NAME} PkgConfig::OPUSFILE)
 
 target_compile_options(${PROJECT_NAME} PRIVATE
         -g -O2 -Wall

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(dualie STATIC
         include/Dualie/Graphics/TextBuffer.hpp
         src/Dualie/Audio/Music.cpp
         include/Dualie/Audio/Music.hpp
+        include/Dualie/Audio.hpp
 )
 
 

--- a/include/Dualie/Audio.hpp
+++ b/include/Dualie/Audio.hpp
@@ -1,0 +1,8 @@
+//
+// Created by caleb on 7/27/24.
+//
+
+#ifndef DUALIE_AUDIO_HPP
+#define DUALIE_AUDIO_HPP
+#include <Dualie/Audio/Music.hpp>
+#endif //DUALIE_AUDIO_HPP

--- a/include/Dualie/Audio/Music.hpp
+++ b/include/Dualie/Audio/Music.hpp
@@ -1,0 +1,61 @@
+//
+// Created by caleb on 7/25/24.
+//
+
+#ifndef DUALIE_MUSIC_HPP
+#define DUALIE_MUSIC_HPP
+#include <iostream>
+#include <cstring>
+#include <opusfile.h>
+#include <3ds.h>
+#include <functional>
+#include <thread>
+
+
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+
+namespace dl
+{
+
+    class Music
+    {
+
+        static constexpr int SAMPLE_RATE = 48000;            // Opus is fixed at 48kHz
+        static constexpr int SAMPLES_PER_BUF = SAMPLE_RATE * 120 / 1000;  // 120ms buffer
+        static constexpr int CHANNELS_PER_SAMPLE = 2;
+
+        static constexpr int THREAD_AFFINITY = -1;           // Execute thread on any core
+        static constexpr int THREAD_STACK_SZ = 32 * 1024;    // 32kB stack for audio thread
+
+        static constexpr size_t WAVEBUF_SIZE = SAMPLES_PER_BUF * CHANNELS_PER_SAMPLE * sizeof(int16_t);
+
+        ndspWaveBuf s_waveBufs[3];
+        int16_t* s_audioBuffer = nullptr;
+
+        OggOpusFile* m_opusFile;
+
+        LightEvent s_event;
+        Thread m_threadId;
+        volatile bool s_quit = false;  // Quit flag
+
+        // Retrieve strings for libopusfile errors
+        // Sourced from David Gow's example code: https://davidgow.net/files/opusal.cpp
+        std::string getOpusErrorString(int error);
+        void audioCallback(void* const nul_);
+        static void callbackWrapper(void* obj);
+        void audioThread();
+        static void threadWrapper(void* obj);
+        bool fillBuffer(ndspWaveBuf* waveBuf_);
+
+    public:
+        Music();
+        ~Music();
+        void loadFromFile(std::string path);
+
+        void start();
+        void stop();
+
+    };
+
+}
+#endif //DUALIE_MUSIC_HPP

--- a/include/Dualie/Audio/Music.hpp
+++ b/include/Dualie/Audio/Music.hpp
@@ -4,6 +4,7 @@
 
 #ifndef DUALIE_MUSIC_HPP
 #define DUALIE_MUSIC_HPP
+
 #include <iostream>
 #include <cstring>
 #include <opusfile.h>
@@ -21,7 +22,6 @@ namespace dl
     {
 
 
-
         ndspWaveBuf m_waveBufs[3];
         int16_t* m_audioBuffer = nullptr;
 
@@ -29,18 +29,18 @@ namespace dl
 
         LightEvent m_event;
         Thread m_threadId;
+
         volatile bool m_quit = false;  // Quit flag
         bool m_looping = false;
 
-        // Retrieve strings for libopusfile errors
-        // Sourced from David Gow's example code: https://davidgow.net/files/opusal.cpp
-        std::string getOpusErrorString(int error);
-        void audioCallback(void* const nul_);
-        static void callbackWrapper(void* obj);
-        void audioThread();
-        static void threadWrapper(void* obj);
         bool fillBuffer(ndspWaveBuf* waveBuf_);
         void allocateBuffers();
+        void reinitialize();
+        void audioCallback(void* const nul_);
+        void audioThread();
+        static void callbackWrapper(void* obj);
+        static void threadWrapper(void* obj);
+        std::string getOpusErrorString(int error);
 
     public:
         Music();
@@ -52,14 +52,11 @@ namespace dl
         void stop();
         void setLooping(bool looping);
 
-        static constexpr int SAMPLE_RATE = 48000;
-        // Opus is fixed at 48kHz
+        static constexpr int SAMPLE_RATE = 48000; // Opus is fixed at 48kHz
         static constexpr int SAMPLES_PER_BUF = SAMPLE_RATE * 120 / 1000;  // 120ms buffer
         static constexpr int CHANNELS_PER_SAMPLE = 2;
-
         static constexpr int THREAD_AFFINITY = -1;           // Execute thread on any core
         static constexpr int THREAD_STACK_SZ = 32 * 1024;    // 32kB stack for audio thread
-
         static constexpr size_t WAVEBUF_SIZE = SAMPLES_PER_BUF * CHANNELS_PER_SAMPLE * sizeof(int16_t);
     };
 

--- a/include/Dualie/Audio/Music.hpp
+++ b/include/Dualie/Audio/Music.hpp
@@ -22,14 +22,15 @@ namespace dl
 
 
 
-        ndspWaveBuf s_waveBufs[3];
-        int16_t* s_audioBuffer = nullptr;
+        ndspWaveBuf m_waveBufs[3];
+        int16_t* m_audioBuffer = nullptr;
 
         OggOpusFile* m_opusFile;
 
-        LightEvent s_event;
+        LightEvent m_event;
         Thread m_threadId;
-        volatile bool s_quit = false;  // Quit flag
+        volatile bool m_quit = false;  // Quit flag
+        bool m_looping = false;
 
         // Retrieve strings for libopusfile errors
         // Sourced from David Gow's example code: https://davidgow.net/files/opusal.cpp
@@ -39,14 +40,17 @@ namespace dl
         void audioThread();
         static void threadWrapper(void* obj);
         bool fillBuffer(ndspWaveBuf* waveBuf_);
+        void allocateBuffers();
 
     public:
         Music();
         ~Music();
         void loadFromFile(std::string path);
 
-        void start();
+        void play();
+        void restart();
         void stop();
+        void setLooping(bool looping);
 
         static constexpr int SAMPLE_RATE = 48000;
         // Opus is fixed at 48kHz

--- a/include/Dualie/Audio/Music.hpp
+++ b/include/Dualie/Audio/Music.hpp
@@ -20,14 +20,7 @@ namespace dl
     class Music
     {
 
-        static constexpr int SAMPLE_RATE = 48000;            // Opus is fixed at 48kHz
-        static constexpr int SAMPLES_PER_BUF = SAMPLE_RATE * 120 / 1000;  // 120ms buffer
-        static constexpr int CHANNELS_PER_SAMPLE = 2;
 
-        static constexpr int THREAD_AFFINITY = -1;           // Execute thread on any core
-        static constexpr int THREAD_STACK_SZ = 32 * 1024;    // 32kB stack for audio thread
-
-        static constexpr size_t WAVEBUF_SIZE = SAMPLES_PER_BUF * CHANNELS_PER_SAMPLE * sizeof(int16_t);
 
         ndspWaveBuf s_waveBufs[3];
         int16_t* s_audioBuffer = nullptr;
@@ -55,6 +48,15 @@ namespace dl
         void start();
         void stop();
 
+        static constexpr int SAMPLE_RATE = 48000;
+        // Opus is fixed at 48kHz
+        static constexpr int SAMPLES_PER_BUF = SAMPLE_RATE * 120 / 1000;  // 120ms buffer
+        static constexpr int CHANNELS_PER_SAMPLE = 2;
+
+        static constexpr int THREAD_AFFINITY = -1;           // Execute thread on any core
+        static constexpr int THREAD_STACK_SZ = 32 * 1024;    // 32kB stack for audio thread
+
+        static constexpr size_t WAVEBUF_SIZE = SAMPLES_PER_BUF * CHANNELS_PER_SAMPLE * sizeof(int16_t);
     };
 
 }

--- a/include/Dualie/Dualie.hpp
+++ b/include/Dualie/Dualie.hpp
@@ -2,5 +2,6 @@
 #define DUALIE_DUALIE_HPP
 #include <Dualie/Graphics.hpp>
 #include <Dualie/System/Input.hpp>
+#include <Dualie/Audio.hpp>
 
 #endif //DUALIE_DUALIE_HPP

--- a/include/Dualie/Graphics/RenderWindow.hpp
+++ b/include/Dualie/Graphics/RenderWindow.hpp
@@ -9,6 +9,7 @@
 #include <Dualie/Graphics/Drawable.hpp>
 #include <Dualie/System/Input.hpp>
 #include <Dualie/Graphics/View.hpp>
+#include <Dualie/Audio/Music.hpp>
 
 namespace dl {
 

--- a/src/Dualie/Audio/Music.cpp
+++ b/src/Dualie/Audio/Music.cpp
@@ -5,7 +5,6 @@
 #include <Dualie/Audio/Music.hpp>
 
 
-
 dl::Music::Music()
 {
     LightEvent_Init(&m_event, RESET_ONESHOT);
@@ -17,12 +16,197 @@ dl::Music::~Music()
     ndspChnReset(0);
     linearFree(m_audioBuffer);
     op_free(m_opusFile);
+}
 
+
+void dl::Music::loadFromFile(std::string path)
+{
+    int error;
+    m_opusFile = op_open_file(path.c_str(), &error);
+    if (error)
+    {
+        printf("Failed to open file: error %d (%s)\n", error,
+               getOpusErrorString(error).c_str());
+    }
+}
+
+void dl::Music::play()
+{
+    // Set the ndsp sound frame callback which signals our audioThread
+    m_quit = false;
+    ndspSetCallback(&dl::Music::callbackWrapper, this);
+
+    // Spawn audio thread
+
+    // Set the thread priority to the main thread's priority ...
+    int32_t priority = 0x30;
+    svcGetThreadPriority(&priority, CUR_THREAD_HANDLE);
+    // ... then subtract 1, as lower number => higher actual priority ...
+    priority -= 1;
+    // ... finally, clamp it between 0x18 and 0x3F to guarantee that it's valid.
+    priority = priority < 0x18 ? 0x18 : priority;
+    priority = priority > 0x3F ? 0x3F : priority;
+
+    // Start the thread, passing our opusFile as an argument.
+    m_threadId = threadCreate(&Music::threadWrapper, this,
+                              THREAD_STACK_SZ, priority,
+                              THREAD_AFFINITY, false);
+}
+
+void dl::Music::restart()
+{
+    if (!m_quit)
+    {
+        stop();
+    }
+    reinitialize();
+    play();
+}
+
+void dl::Music::stop()
+{
+    m_quit = true;
+    LightEvent_Signal(&m_event);
+
+    // Free the audio thread
+    threadJoin(m_threadId, UINT64_MAX);
+    threadFree(m_threadId);
+}
+
+void dl::Music::audioCallback(void* const nul_)
+{
+    (void) nul_;  // Unused
+
+    if (m_quit)
+    { // Quit flag
+        return;
+    }
+
+    LightEvent_Signal(&m_event);
+
+}
+
+void dl::Music::audioThread()
+{
+    while (!m_quit)
+    {  // Whilst the quit flag is unset,
+        // search our waveBufs and fill any that aren't currently
+        // queued for playback (i.e, those that are 'done')
+        for (size_t i = 0; i < ARRAY_SIZE(m_waveBufs); ++i)
+        {
+            if (m_waveBufs[i].status != NDSP_WBUF_DONE)
+            {
+                continue;
+            }
+
+            if (!fillBuffer(&m_waveBufs[i]))
+            {   // Playback complete
+                if (m_looping)
+                {
+                    reinitialize();
+                    continue;
+                }
+                return;
+            }
+        }
+
+        // Wait for a signal that we're needed again before continuing,
+        // so that we can yield to other things that want to run
+        // (Note that the 3DS uses cooperative threading)
+        LightEvent_Wait(&m_event);
+    }
+}
+
+bool dl::Music::fillBuffer(ndspWaveBuf* waveBuf_)
+{
+    // Decode samples until our waveBuf is full
+    int totalSamples = 0;
+    while (totalSamples < SAMPLES_PER_BUF)
+    {
+        int16_t* buffer = waveBuf_->data_pcm16 + (totalSamples *
+                                                  CHANNELS_PER_SAMPLE);
+        const size_t bufferSize = (SAMPLES_PER_BUF - totalSamples) *
+                                  CHANNELS_PER_SAMPLE;
+
+        // Decode bufferSize samples from opusFile_ into buffer,
+        // storing the number of samples that were decoded (or error)
+        const int samples = op_read_stereo(m_opusFile, buffer, bufferSize);
+        if (samples <= 0)
+        {
+            if (samples == 0)
+            { break; }  // No error here
+
+            printf("op_read_stereo: error %d (%s)", samples,
+                   getOpusErrorString(samples).c_str());
+            break;
+        }
+
+        totalSamples += samples;
+    }
+
+    // If no samples were read in the last decode cycle, we're done
+    if (totalSamples == 0)
+    {
+        return false;
+    }
+
+    // Pass samples to NDSP
+    waveBuf_->nsamples = totalSamples;
+    ndspChnWaveBufAdd(0, waveBuf_);
+    DSP_FlushDataCache(waveBuf_->data_pcm16,
+                       totalSamples * CHANNELS_PER_SAMPLE * sizeof(int16_t));
+
+    return true;
+}
+
+
+void dl::Music::allocateBuffers()
+{
+    // Allocate audio buffer
+    const size_t bufferSize = WAVEBUF_SIZE * ARRAY_SIZE(m_waveBufs);
+    m_audioBuffer = (int16_t*) linearAlloc(bufferSize);
+    if (!m_audioBuffer)
+    {
+        exit(-1);
+    }
+
+    // Setup waveBufs for NDSP
+    memset(&m_waveBufs, 0, sizeof(m_waveBufs));
+    int16_t* buffer = m_audioBuffer;
+
+    for (size_t i = 0; i < ARRAY_SIZE(m_waveBufs); ++i)
+    {
+        m_waveBufs[i].data_vaddr = buffer;
+        m_waveBufs[i].status = NDSP_WBUF_DONE;
+
+        buffer += WAVEBUF_SIZE / sizeof(buffer[0]);
+    }
+}
+
+void dl::Music::reinitialize()
+{
+    op_raw_seek(m_opusFile, 0);
+    ndspChnWaveBufClear(0);
+    linearFree(m_audioBuffer);
+    allocateBuffers();
+}
+
+void dl::Music::callbackWrapper(void* obj)
+{
+    dl::Music* music = static_cast<dl::Music*>(obj);
+    music->audioCallback(nullptr);
+}
+
+void dl::Music::threadWrapper(void* obj)
+{
+    dl::Music* music = static_cast<dl::Music*>(obj);
+    music->audioThread();
 }
 
 std::string dl::Music::getOpusErrorString(int error)
 {
-    switch(error) {
+    switch (error)
+    {
         case OP_FALSE:
             return "OP_FALSE: A request did not succeed.";
         case OP_HOLE:
@@ -65,183 +249,11 @@ std::string dl::Music::getOpusErrorString(int error)
 }
 
 
-
-void dl::Music::loadFromFile(std::string path)
-{
-    int error;
-    m_opusFile = op_open_file(path.c_str(), &error);
-    if(error)
-    {
-        printf("Failed to open file: error %d (%s)\n", error,
-               getOpusErrorString(error).c_str());
-    }
-}
-
-void dl::Music::play()
-{
-    // Set the ndsp sound frame callback which signals our audioThread
-    m_quit = false;
-    ndspSetCallback(&dl::Music::callbackWrapper, this);
-
-    // Spawn audio thread
-
-    // Set the thread priority to the main thread's priority ...
-    int32_t priority = 0x30;
-    svcGetThreadPriority(&priority, CUR_THREAD_HANDLE);
-    // ... then subtract 1, as lower number => higher actual priority ...
-    priority -= 1;
-    // ... finally, clamp it between 0x18 and 0x3F to guarantee that it's valid.
-    priority = priority < 0x18 ? 0x18 : priority;
-    priority = priority > 0x3F ? 0x3F : priority;
-
-    // Start the thread, passing our opusFile as an argument.
-    m_threadId = threadCreate(&Music::threadWrapper, this,
-                                         THREAD_STACK_SZ, priority,
-                                         THREAD_AFFINITY, false);
-}
-
-void dl::Music::restart()
-{
-    if(!m_quit)
-    {
-        stop();
-    }
-    op_raw_seek(m_opusFile, 0);
-    ndspChnWaveBufClear(0);
-    linearFree(m_audioBuffer);
-    allocateBuffers();
-    play();
-}
-
-void dl::Music::stop()
-{
-    m_quit = true;
-    LightEvent_Signal(&m_event);
-
-    // Free the audio thread
-    threadJoin(m_threadId, UINT64_MAX);
-    threadFree(m_threadId);
-
-}
-
-void dl::Music::audioCallback(void* const nul_)
-{
-    (void)nul_;  // Unused
-
-    if(m_quit) { // Quit flag
-        return;
-    }
-
-    LightEvent_Signal(&m_event);
-
-}
-
-void dl::Music::audioThread()
-{
-
-
-    while(!m_quit) {  // Whilst the quit flag is unset,
-        // search our waveBufs and fill any that aren't currently
-        // queued for playback (i.e, those that are 'done')
-        for(size_t i = 0; i < ARRAY_SIZE(m_waveBufs); ++i) {
-            if(m_waveBufs[i].status != NDSP_WBUF_DONE) {
-                continue;
-            }
-
-            if(!fillBuffer(&m_waveBufs[i])) {   // Playback complete
-                if(m_looping){
-                    op_raw_seek(m_opusFile, 0);
-                    ndspChnWaveBufClear(0);
-                    linearFree(m_audioBuffer);
-                    allocateBuffers();
-                    continue;
-                }
-                return;
-            }
-        }
-
-        // Wait for a signal that we're needed again before continuing,
-        // so that we can yield to other things that want to run
-        // (Note that the 3DS uses cooperative threading)
-        LightEvent_Wait(&m_event);
-    }
-}
-
-bool dl::Music::fillBuffer(ndspWaveBuf* waveBuf_)
-{
-    // Decode samples until our waveBuf is full
-    int totalSamples = 0;
-    while(totalSamples < SAMPLES_PER_BUF) {
-        int16_t *buffer = waveBuf_->data_pcm16 + (totalSamples *
-                                                  CHANNELS_PER_SAMPLE);
-        const size_t bufferSize = (SAMPLES_PER_BUF - totalSamples) *
-                                  CHANNELS_PER_SAMPLE;
-
-        // Decode bufferSize samples from opusFile_ into buffer,
-        // storing the number of samples that were decoded (or error)
-        const int samples = op_read_stereo(m_opusFile, buffer, bufferSize);
-        if(samples <= 0) {
-            if(samples == 0) break;  // No error here
-
-            printf("op_read_stereo: error %d (%s)", samples,
-                    getOpusErrorString(samples).c_str());
-            break;
-        }
-
-        totalSamples += samples;
-    }
-
-    // If no samples were read in the last decode cycle, we're done
-    if(totalSamples == 0) {
-        return false;
-    }
-
-    // Pass samples to NDSP
-    waveBuf_->nsamples = totalSamples;
-    ndspChnWaveBufAdd(0, waveBuf_);
-    DSP_FlushDataCache(waveBuf_->data_pcm16,
-                       totalSamples * CHANNELS_PER_SAMPLE * sizeof(int16_t));
-
-    return true;
-}
-
-void dl::Music::callbackWrapper(void* obj)
-{
-    dl::Music* music = static_cast<dl::Music*>(obj);
-    music->audioCallback(nullptr);
-}
-
-void dl::Music::threadWrapper(void* obj)
-{
-    dl::Music* music = static_cast<dl::Music*>(obj);
-    music->audioThread();
-}
-
-void dl::Music::allocateBuffers()
-{
-    // Allocate audio buffer
-    const size_t bufferSize = WAVEBUF_SIZE * ARRAY_SIZE(m_waveBufs);
-    m_audioBuffer = (int16_t *)linearAlloc(bufferSize);
-    if(!m_audioBuffer) {
-        exit(-1);
-    }
-
-    // Setup waveBufs for NDSP
-    memset(&m_waveBufs, 0, sizeof(m_waveBufs));
-    int16_t *buffer = m_audioBuffer;
-
-    for(size_t i = 0; i < ARRAY_SIZE(m_waveBufs); ++i) {
-        m_waveBufs[i].data_vaddr = buffer;
-        m_waveBufs[i].status     = NDSP_WBUF_DONE;
-
-        buffer += WAVEBUF_SIZE / sizeof(buffer[0]);
-    }
-}
-
 void dl::Music::setLooping(bool looping)
 {
     m_looping = looping;
 }
+
 
 
 

--- a/src/Dualie/Audio/Music.cpp
+++ b/src/Dualie/Audio/Music.cpp
@@ -9,13 +9,7 @@
 dl::Music::Music()
 {
 
-    // Setup NDSP
-    ndspInit();
-    ndspChnReset(0);
-    ndspSetOutputMode(NDSP_OUTPUT_STEREO);
-    ndspChnSetInterp(0, NDSP_INTERP_POLYPHASE);
-    ndspChnSetRate(0, SAMPLE_RATE);
-    ndspChnSetFormat(0, NDSP_FORMAT_STEREO_PCM16);
+    //Maybe reset channel here
 
     LightEvent_Init(&s_event, RESET_ONESHOT);
 
@@ -43,7 +37,6 @@ dl::Music::~Music()
 {
     ndspChnReset(0);
     linearFree(s_audioBuffer);
-    ndspExit();
     op_free(m_opusFile);
 
 }

--- a/src/Dualie/Audio/Music.cpp
+++ b/src/Dualie/Audio/Music.cpp
@@ -1,0 +1,228 @@
+//
+// Created by caleb on 7/25/24.
+//
+
+#include <Dualie/Audio/Music.hpp>
+
+
+
+dl::Music::Music()
+{
+
+    // Setup NDSP
+    ndspInit();
+    ndspChnReset(0);
+    ndspSetOutputMode(NDSP_OUTPUT_STEREO);
+    ndspChnSetInterp(0, NDSP_INTERP_POLYPHASE);
+    ndspChnSetRate(0, SAMPLE_RATE);
+    ndspChnSetFormat(0, NDSP_FORMAT_STEREO_PCM16);
+
+    LightEvent_Init(&s_event, RESET_ONESHOT);
+
+    // Allocate audio buffer
+    const size_t bufferSize = WAVEBUF_SIZE * ARRAY_SIZE(s_waveBufs);
+    s_audioBuffer = (int16_t *)linearAlloc(bufferSize);
+    if(!s_audioBuffer) {
+        exit(-1);
+    }
+
+    // Setup waveBufs for NDSP
+    memset(&s_waveBufs, 0, sizeof(s_waveBufs));
+    int16_t *buffer = s_audioBuffer;
+
+    for(size_t i = 0; i < ARRAY_SIZE(s_waveBufs); ++i) {
+        s_waveBufs[i].data_vaddr = buffer;
+        s_waveBufs[i].status     = NDSP_WBUF_DONE;
+
+        buffer += WAVEBUF_SIZE / sizeof(buffer[0]);
+    }
+
+}
+
+dl::Music::~Music()
+{
+    ndspChnReset(0);
+    linearFree(s_audioBuffer);
+    ndspExit();
+    op_free(m_opusFile);
+
+}
+
+std::string dl::Music::getOpusErrorString(int error)
+{
+    switch(error) {
+        case OP_FALSE:
+            return "OP_FALSE: A request did not succeed.";
+        case OP_HOLE:
+            return "OP_HOLE: There was a hole in the page sequence numbers.";
+        case OP_EREAD:
+            return "OP_EREAD: An underlying read, seek or tell operation "
+                   "failed.";
+        case OP_EFAULT:
+            return "OP_EFAULT: A NULL pointer was passed where none was "
+                   "expected, or an internal library error was encountered.";
+        case OP_EIMPL:
+            return "OP_EIMPL: The stream used a feature which is not "
+                   "implemented.";
+        case OP_EINVAL:
+            return "OP_EINVAL: One or more parameters to a function were "
+                   "invalid.";
+        case OP_ENOTFORMAT:
+            return "OP_ENOTFORMAT: This is not a valid Ogg Opus stream.";
+        case OP_EBADHEADER:
+            return "OP_EBADHEADER: A required header packet was not properly "
+                   "formatted.";
+        case OP_EVERSION:
+            return "OP_EVERSION: The ID header contained an unrecognised "
+                   "version number.";
+        case OP_EBADPACKET:
+            return "OP_EBADPACKET: An audio packet failed to decode properly.";
+        case OP_EBADLINK:
+            return "OP_EBADLINK: We failed to find data we had seen before or "
+                   "the stream was sufficiently corrupt that seeking is "
+                   "impossible.";
+        case OP_ENOSEEK:
+            return "OP_ENOSEEK: An operation that requires seeking was "
+                   "requested on an unseekable stream.";
+        case OP_EBADTIMESTAMP:
+            return "OP_EBADTIMESTAMP: The first or last granule position of a "
+                   "link failed basic validity checks.";
+        default:
+            return "Unknown error.";
+    }
+}
+
+
+
+void dl::Music::loadFromFile(std::string path)
+{
+    int error;
+    m_opusFile = op_open_file(path.c_str(), &error);
+    if(error)
+    {
+        printf("Failed to open file: error %d (%s)\n", error,
+               getOpusErrorString(error).c_str());
+    }
+}
+
+void dl::Music::start()
+{
+    // Set the ndsp sound frame callback which signals our audioThread
+
+    ndspSetCallback(&dl::Music::callbackWrapper, this);
+
+    // Spawn audio thread
+
+    // Set the thread priority to the main thread's priority ...
+    int32_t priority = 0x30;
+    svcGetThreadPriority(&priority, CUR_THREAD_HANDLE);
+    // ... then subtract 1, as lower number => higher actual priority ...
+    priority -= 1;
+    // ... finally, clamp it between 0x18 and 0x3F to guarantee that it's valid.
+    priority = priority < 0x18 ? 0x18 : priority;
+    priority = priority > 0x3F ? 0x3F : priority;
+
+    // Start the thread, passing our opusFile as an argument.
+    m_threadId = threadCreate(&Music::threadWrapper, this,
+                                         THREAD_STACK_SZ, priority,
+                                         THREAD_AFFINITY, false);
+}
+
+void dl::Music::stop()
+{
+    s_quit = true;
+    LightEvent_Signal(&s_event);
+
+    // Free the audio thread
+    threadJoin(m_threadId, UINT64_MAX);
+    threadFree(m_threadId);
+
+}
+
+void dl::Music::audioCallback(void* const nul_)
+{
+    (void)nul_;  // Unused
+
+    if(s_quit) { // Quit flag
+        return;
+    }
+
+    LightEvent_Signal(&s_event);
+
+}
+
+void dl::Music::audioThread()
+{
+
+
+    while(!s_quit) {  // Whilst the quit flag is unset,
+        // search our waveBufs and fill any that aren't currently
+        // queued for playback (i.e, those that are 'done')
+        for(size_t i = 0; i < ARRAY_SIZE(s_waveBufs); ++i) {
+            if(s_waveBufs[i].status != NDSP_WBUF_DONE) {
+                continue;
+            }
+
+            if(!fillBuffer(&s_waveBufs[i])) {   // Playback complete
+                return;
+            }
+        }
+
+        // Wait for a signal that we're needed again before continuing,
+        // so that we can yield to other things that want to run
+        // (Note that the 3DS uses cooperative threading)
+        LightEvent_Wait(&s_event);
+    }
+}
+
+bool dl::Music::fillBuffer(ndspWaveBuf* waveBuf_)
+{
+    // Decode samples until our waveBuf is full
+    int totalSamples = 0;
+    while(totalSamples < SAMPLES_PER_BUF) {
+        int16_t *buffer = waveBuf_->data_pcm16 + (totalSamples *
+                                                  CHANNELS_PER_SAMPLE);
+        const size_t bufferSize = (SAMPLES_PER_BUF - totalSamples) *
+                                  CHANNELS_PER_SAMPLE;
+
+        // Decode bufferSize samples from opusFile_ into buffer,
+        // storing the number of samples that were decoded (or error)
+        const int samples = op_read_stereo(m_opusFile, buffer, bufferSize);
+        if(samples <= 0) {
+            if(samples == 0) break;  // No error here
+
+            printf("op_read_stereo: error %d (%s)", samples,
+                    getOpusErrorString(samples).c_str());
+            break;
+        }
+
+        totalSamples += samples;
+    }
+
+    // If no samples were read in the last decode cycle, we're done
+    if(totalSamples == 0) {
+        return false;
+    }
+
+    // Pass samples to NDSP
+    waveBuf_->nsamples = totalSamples;
+    ndspChnWaveBufAdd(0, waveBuf_);
+    DSP_FlushDataCache(waveBuf_->data_pcm16,
+                       totalSamples * CHANNELS_PER_SAMPLE * sizeof(int16_t));
+
+    return true;
+}
+
+void dl::Music::callbackWrapper(void* obj)
+{
+    dl::Music* music = static_cast<dl::Music*>(obj);
+    music->audioCallback(nullptr);
+}
+
+void dl::Music::threadWrapper(void* obj)
+{
+    dl::Music* music = static_cast<dl::Music*>(obj);
+    music->audioThread();
+}
+
+

--- a/src/Dualie/Graphics/RenderWindow.cpp
+++ b/src/Dualie/Graphics/RenderWindow.cpp
@@ -17,6 +17,13 @@ dl::RenderWindow::RenderWindow() {
     m_screens[TOP_SCREEN] = C2D_CreateScreenTarget(GFX_TOP, GFX_LEFT);
     m_screens[BOTTOM_SCREEN] = C2D_CreateScreenTarget(GFX_BOTTOM, GFX_LEFT);
 
+    ndspInit();
+    ndspChnReset(0);
+    ndspSetOutputMode(NDSP_OUTPUT_STEREO);
+    ndspChnSetInterp(0, NDSP_INTERP_POLYPHASE);
+    ndspChnSetRate(0, Music::SAMPLE_RATE);
+    ndspChnSetFormat(0, NDSP_FORMAT_STEREO_PCM16);
+
 }
 
 dl::RenderWindow::~RenderWindow() {
@@ -25,6 +32,7 @@ dl::RenderWindow::~RenderWindow() {
     romfsExit();
     cfguExit();
     gfxExit();
+    ndspExit();
 }
 
 


### PR DESCRIPTION
The loading of opus audio files is now supported. It includes start, stop, restart, and looping functionality. The code was heavily based on the opus-decoding example from devkitPro.  