### PR TITLE
Add sprites and spritesheets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,10 @@ add_library(dualie STATIC
         src/Dualie/Audio/Music.cpp
         include/Dualie/Audio/Music.hpp
         include/Dualie/Audio.hpp
+        src/Dualie/Graphics/Sprite.cpp
+        include/Dualie/Graphics/Sprite.hpp
+        src/Dualie/Graphics/SpriteSheet.cpp
+        include/Dualie/Graphics/SpriteSheet.hpp
 )
 
 

--- a/include/Dualie/Graphics.hpp
+++ b/include/Dualie/Graphics.hpp
@@ -14,11 +14,8 @@
 #include <Dualie/Graphics/RectangleShape.hpp>
 #include <Dualie/Graphics/View.hpp>
 #include <Dualie/Graphics/Text.hpp>
-
-namespace dl {
-
-
-}
+#include <Dualie/Graphics/SpriteSheet.hpp>
+#include <Dualie/Graphics/Sprite.hpp>
 
 
 #endif //DUALIE_GRAPHICS_HPP

--- a/include/Dualie/Graphics/CircleShape.hpp
+++ b/include/Dualie/Graphics/CircleShape.hpp
@@ -17,7 +17,7 @@ public:
 
     void setRadius(float radius);
 
-    void draw(const dl::Vector2f& viewOffset) const override;
+    void draw(const dl::Vector2f& viewOffset) override;
 
 protected:
     float m_radius;

--- a/include/Dualie/Graphics/Drawable.hpp
+++ b/include/Dualie/Graphics/Drawable.hpp
@@ -12,7 +12,7 @@ namespace dl {
     class Drawable {
 
     public:
-        virtual void draw(const dl::Vector2f& viewOffset) const = 0;
+        virtual void draw(const dl::Vector2f& viewOffset) = 0;
 
 
     };

--- a/include/Dualie/Graphics/RectangleShape.hpp
+++ b/include/Dualie/Graphics/RectangleShape.hpp
@@ -20,7 +20,7 @@ namespace dl {
 
         void setSize(const dl::Vector2f &size);
 
-        void draw(const dl::Vector2f& viewOffset) const override;
+        void draw(const dl::Vector2f& viewOffset) override;
 
     };
 

--- a/include/Dualie/Graphics/RenderWindow.hpp
+++ b/include/Dualie/Graphics/RenderWindow.hpp
@@ -29,7 +29,7 @@ namespace dl {
         void print(std::string str, int x, int y);
 
         void clear(SCREEN screen, Color color = dl::Color(255, 255, 255));
-        void draw(const dl::Drawable& drawable);
+        void draw(dl::Drawable& drawable);
         void display();
         bool isOpen();
 

--- a/include/Dualie/Graphics/Sprite.hpp
+++ b/include/Dualie/Graphics/Sprite.hpp
@@ -1,0 +1,44 @@
+//
+// Created by caleb on 7/28/24.
+//
+
+#ifndef DUALIE_SPRITE_HPP
+#define DUALIE_SPRITE_HPP
+#include <citro2d.h>
+#include <Dualie/Graphics/Transformable.hpp>
+#include <Dualie/Graphics/Drawable.hpp>
+#include <Dualie/Graphics/SpriteSheet.hpp>
+
+
+namespace dl
+{
+
+    class Sprite : public dl::Transformable, public dl::Drawable
+    {
+
+        C2D_Sprite m_sprite{};
+        float m_rotation{};
+        dl::Vector2f m_origin;
+
+    public:
+
+        Sprite();
+
+        void loadFromSpriteSheet(SpriteSheet spriteSheet, size_t index);
+
+        void draw(const dl::Vector2f &viewOffset) override;
+        void setPosition(const dl::Vector2f &position) override;
+        void move(const dl::Vector2f &offset) override;
+        void setRotation(const float &rotation);
+        const float &getRotation();
+        void rotate(const float &rotationOffset);
+
+        friend C2D_SpriteSheet SpriteSheet::getSpriteSheet();
+
+
+    };
+
+}
+
+
+#endif //DUALIE_SPRITE_HPP

--- a/include/Dualie/Graphics/SpriteSheet.hpp
+++ b/include/Dualie/Graphics/SpriteSheet.hpp
@@ -1,0 +1,25 @@
+//
+// Created by caleb on 7/28/24.
+//
+
+#ifndef DUALIE_SPRITESHEET_HPP
+#define DUALIE_SPRITESHEET_HPP
+#include <citro2d.h>
+#include <string>
+
+
+namespace dl
+{
+    class SpriteSheet
+    {
+        C2D_SpriteSheet m_spriteSheet;
+
+    public:
+        void loadFromFile(const std::string &path);
+        C2D_SpriteSheet getSpriteSheet();
+
+    };
+}
+
+
+#endif //DUALIE_SPRITESHEET_HPP

--- a/include/Dualie/Graphics/Text.hpp
+++ b/include/Dualie/Graphics/Text.hpp
@@ -58,7 +58,7 @@ class Text : public dl::Transformable, public dl::Drawable
         const dl::Vector2f& getOrigin();
         const dl::Vector2f& getScale();
 
-        void draw(const dl::Vector2f &viewOffset) const override;
+        void draw(const dl::Vector2f &viewOffset) override;
 
 
     };

--- a/include/Dualie/Graphics/Transformable.hpp
+++ b/include/Dualie/Graphics/Transformable.hpp
@@ -17,9 +17,9 @@ namespace dl {
 
 
     public:
-        void setPosition(const dl::Vector2f& position);
+        virtual void setPosition(const dl::Vector2f& position);
         void setPosition(float x, float y);
-        void move(const dl::Vector2f& offset);
+        virtual void move(const dl::Vector2f& offset);
         void move(float xOffset, float yOffset);
 
         const dl::Vector2f& getPosition() const;

--- a/src/Dualie/Graphics/CircleShape.cpp
+++ b/src/Dualie/Graphics/CircleShape.cpp
@@ -17,7 +17,7 @@ void dl::CircleShape::setRadius(float radius) {
     m_size = dl::Vector2f(radius*2, radius*2);
 }
 
-void dl::CircleShape::draw(const dl::Vector2f& viewOffset) const {
+void dl::CircleShape::draw(const dl::Vector2f& viewOffset) {
     if(m_outlineThickness > 0){
         C2D_DrawCircle(m_position.x + m_radius - m_origin.x - viewOffset.x, m_position.y + m_radius - m_origin.y - viewOffset.y, 0, m_radius, m_outlineColor.getColorValue(), m_outlineColor.getColorValue(), m_outlineColor.getColorValue(), m_outlineColor.getColorValue());
     }

--- a/src/Dualie/Graphics/RectangleShape.cpp
+++ b/src/Dualie/Graphics/RectangleShape.cpp
@@ -16,7 +16,7 @@ void dl::RectangleShape::setSize(const dl::Vector2f &size) {
     m_size = size;
 }
 
-void dl::RectangleShape::draw(const dl::Vector2f& viewOffset) const {
+void dl::RectangleShape::draw(const dl::Vector2f& viewOffset)  {
     if(m_outlineThickness > 0){
         C2D_DrawRectSolid(m_position.x - m_origin.x - viewOffset.x, m_position.y - m_origin.y - viewOffset.y, 0, m_size.x, m_size.y, m_outlineColor.getColorValue());
     }

--- a/src/Dualie/Graphics/RenderWindow.cpp
+++ b/src/Dualie/Graphics/RenderWindow.cpp
@@ -60,7 +60,7 @@ void dl::RenderWindow::clear(SCREEN screen, Color color) {
     C2D_SceneBegin(m_screens[screen]);
 }
 
-void dl::RenderWindow::draw(const dl::Drawable &drawable) {
+void dl::RenderWindow::draw(dl::Drawable &drawable) {
     drawable.draw(m_view.getOffset());
 }
 

--- a/src/Dualie/Graphics/Sprite.cpp
+++ b/src/Dualie/Graphics/Sprite.cpp
@@ -1,0 +1,57 @@
+//
+// Created by caleb on 7/28/24.
+//
+
+#include <Dualie/Graphics/Sprite.hpp>
+
+dl::Sprite::Sprite()
+{
+    C2D_SpriteSetCenter(&m_sprite, 0.f,0.f);
+}
+
+
+
+void dl::Sprite::setPosition(const dl::Vector2f &position)
+{
+    Transformable::setPosition(position);
+}
+
+void dl::Sprite::move(const dl::Vector2f &offset)
+{
+    Transformable::move(offset);
+}
+
+void dl::Sprite::setRotation(const float &rotation)
+{
+    m_rotation = rotation;
+    C2D_SpriteSetRotation(&m_sprite, rotation);
+}
+
+void dl::Sprite::rotate(const float &rotationOffset)
+{
+    m_rotation += rotationOffset;
+    C2D_SpriteRotate(&m_sprite, rotationOffset);
+}
+
+
+
+const float& dl::Sprite::getRotation()
+{
+    return m_rotation;
+}
+
+
+void dl::Sprite::draw(const dl::Vector2f &viewOffset)
+{
+    C2D_SpriteSetPos(&m_sprite, m_position.x - m_origin.x - viewOffset.x, m_position.y - m_origin.y - viewOffset.y);
+    C2D_DrawSprite(&m_sprite);
+}
+
+void dl::Sprite::loadFromSpriteSheet(SpriteSheet spriteSheet, size_t index)
+{
+    C2D_SpriteFromSheet(&m_sprite, spriteSheet.getSpriteSheet(), index);
+}
+
+
+
+

--- a/src/Dualie/Graphics/SpriteSheet.cpp
+++ b/src/Dualie/Graphics/SpriteSheet.cpp
@@ -1,0 +1,18 @@
+//
+// Created by caleb on 7/28/24.
+//
+
+#include <Dualie/Graphics/SpriteSheet.hpp>
+
+C2D_SpriteSheet dl::SpriteSheet::getSpriteSheet()
+{
+    return m_spriteSheet;
+}
+
+void dl::SpriteSheet::loadFromFile(const std::string &path)
+{
+    m_spriteSheet = C2D_SpriteSheetLoad(path.c_str());
+    if(!m_spriteSheet){
+        printf("Failed to load spritesheet\n");
+    }
+}

--- a/src/Dualie/Graphics/Text.cpp
+++ b/src/Dualie/Graphics/Text.cpp
@@ -18,7 +18,7 @@ dl::Text::~Text()
     C2D_FontFree(m_defaultFont);
 }
 
-void dl::Text::draw(const dl::Vector2f &viewOffset) const
+void dl::Text::draw(const dl::Vector2f &viewOffset)
 {
     C2D_DrawText(&m_textBuf, m_alignment, m_position.x - m_origin.x, m_position.y - m_origin.y, 0, m_scale.x, m_scale.y);
 }

--- a/src/Dualie/Graphics/TextBuffer.cpp
+++ b/src/Dualie/Graphics/TextBuffer.cpp
@@ -2,7 +2,7 @@
 // Created by caleb on 7/20/24.
 //
 
-#include "Dualie/Graphics/TextBuffer.hpp"
+#include <Dualie/Graphics/TextBuffer.hpp>
 
 dl::TextBuffer::TextBuffer(size_t bufSize)
 {

--- a/src/Dualie/Graphics/Transformable.cpp
+++ b/src/Dualie/Graphics/Transformable.cpp
@@ -10,8 +10,7 @@ void dl::Transformable::setPosition(const dl::Vector2f& position) {
 }
 
 void dl::Transformable::setPosition(float x, float y) {
-    m_position.x = x;
-    m_position.y = y;
+    setPosition(dl::Vector2f(x,y));
 }
 
 const dl::Vector2f &dl::Transformable::getPosition() const{
@@ -24,6 +23,5 @@ void dl::Transformable::move(const dl::Vector2f &offset) {
 }
 
 void dl::Transformable::move(float xOffset, float yOffset) {
-    m_position.x += xOffset;
-    m_position.y += yOffset;
+    move(dl::Vector2f(xOffset,yOffset));
 }


### PR DESCRIPTION
Requires t3x spritesheet files which is a bit of a pain to generate with cmake (still haven't figured out how to automate it) when testing I manually create the files using tex3ds. Sprites require a Spritesheet object to load its image from, and is very similar to a Shape object. The const qualifier was also removed from the draw functions due to sprites needing to change some internal attributes at drawtime. This was necessary and will allow for similar functionality in the future since we are using an underlying library anyway. 