### PR TITLE
Fix crashing bug

### DIFF
--- a/src/Dualie/Audio/Music.cpp
+++ b/src/Dualie/Audio/Music.cpp
@@ -13,6 +13,7 @@ dl::Music::Music()
 
 dl::Music::~Music()
 {
+    stop();
     ndspChnReset(0);
     linearFree(m_audioBuffer);
     op_free(m_opusFile);
@@ -65,6 +66,10 @@ void dl::Music::restart()
 
 void dl::Music::stop()
 {
+    if(m_quit)
+    {
+        return;
+    }
     m_quit = true;
     LightEvent_Signal(&m_event);
 


### PR DESCRIPTION
Since the audio thread is never joined/freed in the music destructor, it causes a data abort. This fix simply stops the music playback in the destructor. I also fixed a potential bug by causing `Music::stop` to have no effect if the music is not currently playing. 